### PR TITLE
Ensure encrypted messages end with a newline character.

### DIFF
--- a/src/components/EncryptMessage.js
+++ b/src/components/EncryptMessage.js
@@ -86,8 +86,9 @@ export default class EncryptMessage extends Component {
     if (this.state.sign) {
       privateKey.decrypt(this.state.passphrase);
     }
+    const message = this.state.message.replace(/\n?$/, '\n');
     openpgp.encrypt({
-      data: this.state.message,
+      data: message,
       publicKeys: openpgp.key.readArmored(this.user.publicKey).keys,
       privateKeys: this.state.sign && privateKey,
     }).then(ciphertext => (


### PR DESCRIPTION
This just ensures messages have a newline character for better decoding.

<img width="605" alt="1___usr_local_bin_tmux__tmux_" src="https://user-images.githubusercontent.com/769039/34738914-742e3484-f52f-11e7-8206-10b29f550553.png">
