### PR TITLE
Configure openpgp to not show headers/comments.

### DIFF
--- a/src/configpgp.js
+++ b/src/configpgp.js
@@ -1,0 +1,4 @@
+const openpgp = require('openpgp');
+
+openpgp.config.show_version = false;
+openpgp.config.show_comment = false;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { render as renderReact } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
 import 'normalize.css';
+import './configpgp';
 
 import App from './components/App';
 


### PR DESCRIPTION
This allows users to be more anonymous since they aren't using a common or
default pgp library for encryption.

This will generate:

~~~
-----BEGIN PGP MESSAGE-----

wcFMAypi3dWWd7TsAQ/+LjNeofF+V0T4g+VBQd1Xyb8pIsQXjSltRtFbB6N7
...
zooNrg==
=rgCK
-----END PGP MESSAGE-----
~~~

Instead of:

~~~
-----BEGIN PGP MESSAGE-----
Version: OpenPGP.js v2.3.5
Comment: http://openpgpjs.org

wcFMAypi3dWWd7TsAQ/+LjNeofF+V0T4g+VBQd1Xyb8pIsQXjSltRtFbB6N7
...
zooNrg==
=rgCK
-----END PGP MESSAGE-----
~~~