### PR TITLE
Don't let the menu create a scroll bar when closed.

### DIFF
--- a/src/components/ui/Menu.js
+++ b/src/components/ui/Menu.js
@@ -32,6 +32,9 @@ const componentStyles = StyleSheet.create({
     backgroundColor: colours.midnightBlue,
     color: colours.clouds,
   },
+  menuClosed: {
+    overflow: 'hidden',
+  },
   menuOpen: {
     height: '100%',
   },
@@ -76,7 +79,7 @@ export default class Menu extends Component {
         <ul
           className={css(
             component,
-            this.state.menuOpen && componentStyles.menuOpen,
+            this.state.menuOpen ? componentStyles.menuOpen : componentStyles.menuClosed,
           )}
         >
           <li className={css(componentStyles.li, componentStyles.fullButton)}>{addFriendButton}</li>


### PR DESCRIPTION
This fixes a small scrolling issue I've been having, seen below:

<img width="734" alt="simple_pgp_and_simple-pgp-mas-x64_and_1___usr_local_bin_tmux__tmux_" src="https://user-images.githubusercontent.com/769039/34744395-e9373cb4-f541-11e7-89bd-b467f8d23a20.png">
